### PR TITLE
Types update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[0.0.6]](https://github.com/multiversx/mx-sdk-js-metamask-provider)] - 2024-09-09
+## [[0.0.7]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/3)] - 2024-09-09
+- [Updated types export to out folder](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/3)
+
+## [[0.0.6]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/1)] - 2024-09-09
 - [Update to yarn, @multiversx/sdk-core 13.0.0 as peer depenency](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/2)
 - [Merge development to main](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [[0.0.7]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/3)] - 2024-09-09
+## [[0.0.7]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/4)] - 2024-09-09
 - [Updated types export to out folder](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/3)
 
 ## [[0.0.6]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/1)] - 2024-09-09

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "MultiversX",
   "main": "out/index.js",
   "module": "out/index.js",
-  "types": "out/types/index.d.ts",
+  "types": "out/index.d.ts",
   "directories": {
     "lib": "src"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-metamask-provider",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Signing provider for dApps: Metamask Snap",
   "license": "GPL-3.0-or-later",
   "author": "MultiversX",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "skipLibCheck": true,
         "jsx": "react",
         "allowSyntheticDefaultImports": true,
-        "declarationDir": "./out/types",
+        "declarationDir": "./out",
         "declaration": true
     },
     "include": [


### PR DESCRIPTION
### Issue
unable to import like 
`import { MetamaskProvider } from '@multiversx/sdk-metamask-provider/out/metamaskProvider';`

### Reproduce
Issue exists on version `0.0.6` of mx-sdk-js-metamask-provider

### Root cause
  `"types": "out/types/index.d.ts",` in package json

### Fix
update tsconfig.json

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
