### PR TITLE
Refactor MetamaskProvider to improve error handling and provider detection (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed invalid params passed to invoked getAddress method](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/11)
+- [Refactor MetamaskProvider to improve error handling and provider detection](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/11)
 
 ## [[2.0.0]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/7)] - 2025-03-26
 - [Upgrade sdk-core to v14](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed invalid params passed to invoked getAddress method](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/11)
+
 ## [[2.0.0]](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/7)] - 2025-03-26
 - [Upgrade sdk-core to v14](https://github.com/multiversx/mx-sdk-js-metamask-provider/pull/6)
 

--- a/src/metamaskProvider.ts
+++ b/src/metamaskProvider.ts
@@ -5,7 +5,10 @@ import { safeWindow } from './constants';
 import {
   ErrAccountNotConnected,
   ErrCannotSignSingleTransaction,
-  ErrTransactionCancelled
+  ErrProviderNotInitialized,
+  ErrCouldNotLogin,
+  ErrCouldNotSignTransactions,
+  ErrCouldNotSignMessage
 } from './errors';
 import { connectSnap, getSnap } from './snap';
 
@@ -29,29 +32,49 @@ declare global {
 export class MetamaskProvider {
   public account: IMetamaskWalletAccount = { address: '' };
   private initialized = false;
-  private static _instance: MetamaskProvider = new MetamaskProvider();
+  private static _instance: MetamaskProvider;
 
   public static isMetamaskInstalled(): boolean {
-    return Boolean(
-      safeWindow && safeWindow.ethereum && safeWindow.ethereum.isMetaMask
-    );
+    return MetamaskProvider.getMetamaskProvider() !== null;
   }
 
-  private constructor() {
-    if (MetamaskProvider._instance) {
-      throw new Error(
-        'Error: Instantiation failed: Use MetamaskProvider.getInstance() instead of new.'
-      );
+  private static getMetamaskProvider(): MetaMaskInpageProvider | null {
+    const eth = safeWindow?.ethereum;
+
+    if (!eth) {
+      return null;
     }
-    MetamaskProvider._instance = this;
+
+    if (eth.isMetaMask && typeof eth.request === 'function') {
+      return eth;
+    }
+
+    const providers = eth.providers ?? eth.detected ?? [];
+
+    for (const provider of providers) {
+      if (provider.isMetaMask && typeof provider.request === 'function') {
+        if (typeof eth.setProvider === 'function') {
+          eth.setProvider(provider);
+        }
+
+        return provider;
+      }
+    }
+
+    return null;
   }
 
   public static getInstance(): MetamaskProvider {
+    if (!MetamaskProvider._instance) {
+      MetamaskProvider._instance = new MetamaskProvider();
+    }
+
     return MetamaskProvider._instance;
   }
 
   public setAddress(address: string): MetamaskProvider {
     this.account.address = address;
+
     return MetamaskProvider._instance;
   }
 
@@ -72,9 +95,11 @@ export class MetamaskProvider {
         const installedSnap = await getSnap();
         this.initialized = installedSnap !== undefined;
       } catch (error) {
+        console.error('MetamaskProvider init failed:', error);
         this.initialized = false;
       }
     }
+
     return this.initialized;
   }
 
@@ -84,27 +109,36 @@ export class MetamaskProvider {
     } = {}
   ): Promise<IMetamaskWalletAccount> {
     const token = options.token;
+
     if (!this.initialized) {
-      throw new Error(
-        'Metamask provider is not initialised, call init() first' + token
-      );
+      throw new ErrProviderNotInitialized();
     }
+
     try {
-      const address = (await safeWindow?.ethereum?.request({
+      const provider = MetamaskProvider.getMetamaskProvider();
+
+      if (!provider) {
+        throw new ErrCouldNotLogin();
+      }
+
+      const addressResponse = await provider.request({
         method: 'wallet_invokeSnap',
         params: {
           snapId: defaultSnapOrigin,
           request: {
-            method: 'mvx_getAddress',
-            params: undefined
+            method: 'mvx_getAddress'
           }
         }
-      })) as string;
+      });
 
-      this.account.address = address;
+      if (!addressResponse || typeof addressResponse !== 'string') {
+        throw new ErrCouldNotLogin();
+      }
+
+      this.account.address = addressResponse;
 
       if (token) {
-        const tokenSigned = (await safeWindow?.ethereum?.request({
+        const tokenResponse = await provider.request({
           method: 'wallet_invokeSnap',
           params: {
             snapId: defaultSnapOrigin,
@@ -113,21 +147,25 @@ export class MetamaskProvider {
               params: { token: token }
             }
           }
-        })) as string;
+        });
 
-        this.account.signature = tokenSigned;
+        if (!tokenResponse || typeof tokenResponse !== 'string') {
+          throw new ErrCouldNotLogin();
+        }
+
+        this.account.signature = tokenResponse;
       }
     } catch (error: any) {
-      throw error;
+      console.error('MetamaskProvider login failed:', error);
+      throw new ErrCouldNotLogin();
     }
+
     return this.account;
   }
 
   async logout(): Promise<boolean> {
     if (!this.initialized) {
-      throw new Error(
-        'Metamask provider is not initialised, call init() first'
-      );
+      throw new ErrProviderNotInitialized();
     }
 
     this.account = { address: '' };
@@ -137,11 +175,10 @@ export class MetamaskProvider {
 
   async getAddress(): Promise<string> {
     if (!this.initialized) {
-      throw new Error(
-        'Metamask provider is not initialised, call init() first'
-      );
+      throw new ErrProviderNotInitialized();
     }
-    return this.account ? this.account.address : '';
+
+    return this.account?.address ?? '';
   }
 
   isInitialized(): boolean {
@@ -164,11 +201,18 @@ export class MetamaskProvider {
 
   async signTransactions(transactions: Transaction[]): Promise<Transaction[]> {
     try {
+      this.ensureConnected();
+      const provider = MetamaskProvider.getMetamaskProvider();
+
+      if (!provider) {
+        throw new ErrCouldNotSignTransactions();
+      }
+
       const transactionsPlain = transactions.map((transaction) =>
         transaction.toPlainObject()
       );
 
-      const metamaskReponse = (await safeWindow?.ethereum?.request({
+      const signResponse = await provider.request({
         method: 'wallet_invokeSnap',
         params: {
           snapId: defaultSnapOrigin,
@@ -177,23 +221,33 @@ export class MetamaskProvider {
             params: { transactions: transactionsPlain }
           }
         }
-      })) as string[];
+      });
 
-      const transactionsResponse = metamaskReponse.map((transaction: string) =>
-        Transaction.fromPlainObject(JSON.parse(transaction))
+      if (!Array.isArray(signResponse)) {
+        throw new ErrCouldNotSignTransactions();
+      }
+
+      const transactionsResponse = signResponse.map((transaction: string) =>
+        Transaction.newFromPlainObject(JSON.parse(transaction))
       );
 
       return transactionsResponse;
     } catch (error) {
-      throw new ErrTransactionCancelled();
+      console.error('MetamaskProvider signTransactions failed:', error);
+      throw new ErrCouldNotSignTransactions();
     }
   }
 
   async signMessage(messageToSign: Message): Promise<Message> {
     try {
       this.ensureConnected();
+      const provider = MetamaskProvider.getMetamaskProvider();
 
-      const metamaskReponse = (await safeWindow?.ethereum?.request({
+      if (!provider) {
+        throw new ErrCouldNotSignMessage();
+      }
+
+      const signResponse = await provider.request({
         method: 'wallet_invokeSnap',
         params: {
           snapId: defaultSnapOrigin,
@@ -202,18 +256,23 @@ export class MetamaskProvider {
             params: { message: Buffer.from(messageToSign.data).toString() }
           }
         }
-      })) as string;
+      });
+
+      if (!signResponse || typeof signResponse !== 'string') {
+        throw new ErrCouldNotSignMessage();
+      }
 
       return new Message({
         data: Buffer.from(messageToSign.data),
         address:
-          messageToSign.address ?? Address.fromBech32(this.account.address),
+          messageToSign.address ?? Address.newFromBech32(this.account.address),
         signer: 'metamask',
         version: messageToSign.version,
-        signature: Buffer.from(metamaskReponse, 'hex')
+        signature: Buffer.from(signResponse, 'hex')
       });
     } catch (error) {
-      throw error;
+      console.error('MetamaskProvider signMessage failed:', error);
+      throw new ErrCouldNotSignMessage();
     }
   }
 
@@ -223,6 +282,7 @@ export class MetamaskProvider {
 
   private ensureConnected() {
     const hasMetamask = MetamaskProvider.isMetamaskInstalled();
+
     if (!this.account.address || !hasMetamask) {
       throw new ErrAccountNotConnected();
     }


### PR DESCRIPTION
### Issue
Metamask login does not work in firefox.

### Reproduce
Try to login in https://devnet-wallet.multiversx.com/ in Firefox with Metamask.

### Root cause
1. Metamask provider detection does not include the firefox metamask detection
2. `undefined` is passed to the `mvx_getAddress` snap method invoke, instead of not passing params at all

### Fix
1. Removed `undefined` params assignment at `mvx_getAddress`
2. In Chrome, if you have multiple EIP-1193 wallets installed, MetaMask populates `window.ethereum.providers`. We iterate that array and select the entry where `isMetaMask === true` and `request` exists.
3. Older Firefox MetaMask builds used `window.ethereum.detected` instead of providers. We only fall back to detected if providers is absent.
4. Firefox’s Content Security Policy restrictions sometimes require explicitly calling `ethereum.setProvider(provider)` to activate the chosen provider

### Additional changes
- Added error logs
- Added more intuitive error objects
- Initialize the `MetamaskProvider` intstance only when `getInstance` is called (if not already initialized)
- Call `this.ensureConnected();` not only in `signMessage`, but also in `signTransactions`

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
